### PR TITLE
Fixed build error when CONFIG_VIDEO is not set.

### DIFF
--- a/drivers/video/mxc_ipuv3_fb.c
+++ b/drivers/video/mxc_ipuv3_fb.c
@@ -425,8 +425,9 @@ static int mxcfb_map_video_memory(struct fb_info *fbi)
 	debug("allocated fb @ paddr=0x%08X, size=%d.\n",
 		(uint32_t) fbi->fix.smem_start, fbi->fix.smem_len);
 
-
+#if defined(CONFIG_LCD) || defined(CONFIG_VIDEO)
 	gd->fb_base = fbi->fix.smem_start;
+#endif
 
 	/* Clear the screen */
 	memset((char *)fbi->screen_base, 0, fbi->fix.smem_len);


### PR DESCRIPTION
In file "include/asm-generic/glibal-data.h" struct member var fb_base is declared as follows:
```
typedef struct global_data {
	bd_t *bd;
	unsigned long flags;
	unsigned int baudrate;
	unsigned long cpu_clk;		/* CPU clock in Hz!		*/
	unsigned long bus_clk;
	/* We cannot bracket this with CONFIG_PCI due to mpc5xxx */
	unsigned long pci_clk;
	unsigned long mem_clk;
#if defined(CONFIG_LCD) || defined(CONFIG_VIDEO)
	unsigned long fb_base;		/* Base address of framebuffer mem */
#endif
```
In this line, a compilation error if CONFIG_VIDEO is not set.