### PR TITLE
fastboot: reboot bootloader: add stuff for imx8

### DIFF
--- a/arch/arm/mach-imx/imx8m/Makefile
+++ b/arch/arm/mach-imx/imx8m/Makefile
@@ -4,6 +4,7 @@
 
 obj-y += lowlevel_init.o
 obj-y += clock_slice.o soc.o
+obj-$(CONFIG_FASTBOOT) += fastboot.o
 obj-$(CONFIG_IMX8MQ) += clock_imx8mq.o
 obj-$(CONFIG_IMX8MM)$(CONFIG_IMX8MN) += clock_imx8mm.o
 obj-$(CONFIG_VIDEO_IMXDCSS) += video_common.o

--- a/arch/arm/mach-imx/imx8m/fastboot.c
+++ b/arch/arm/mach-imx/imx8m/fastboot.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2020 Adrien Grassein <adrien.grassein@smile.fr>
+ *
+ * Fastboot specific functions for imx8m
+ */
+
+#include <linux/types.h>
+#include <common.h>
+#include <fastboot.h>
+
+/**
+ * fastboot_set_reboot_flag() - Set flag to indicate reboot-bootloader
+ *
+ * Set flag which indicates that we should reboot into the bootloader
+ * following the reboot that fastboot executes after this function.
+ */
+int fastboot_set_reboot_flag(void) {
+	char cmd[64];
+
+	snprintf(cmd, sizeof(cmd), "bcb load %d misc",
+		 CONFIG_FASTBOOT_FLASH_MMC_DEV);
+
+	if (run_command(cmd, 0))
+		return -ENODEV;
+
+	if (run_command("bcb set command bootonce-bootloader", 0))
+		return -ENOEXEC;
+
+	if (run_command("bcb store", 0))
+		return -EIO;
+
+	return 0;
+}


### PR DESCRIPTION
Add reboot flag function for imx8.
This is necessary for "fastboot reboot bootloader"
command.

Signed-off-by: Adrien Grassein <adrien.grassein@smile.fr>