### PR TITLE
fastboot: implement getvar mem-size

### DIFF
--- a/drivers/fastboot/fb_getvar.c
+++ b/drivers/fastboot/fb_getvar.c
@@ -10,9 +10,12 @@
 #include <fb_mmc.h>
 #include <fb_nand.h>
 #include <fs.h>
+#include <inttypes.h>
 #include <mmc.h>
 #include <part.h>
 #include <version.h>
+
+DECLARE_GLOBAL_DATA_PTR;
 
 static void getvar_version(char *var_parameter, char *response);
 static void getvar_version_bootloader(char *var_parameter, char *response);
@@ -33,6 +36,7 @@ static void getvar_partition_type(char *part_name, char *response);
 static void getvar_partition_size(char *part_name, char *response);
 #endif
 static void getvar_is_userspace(char *var_parameter, char *response);
+static void getvar_mem_size(char *part_name, char *response);
 
 static const struct {
 	const char *variable;
@@ -86,6 +90,9 @@ static const struct {
 	}, {
 		.variable = "is-userspace",
 		.dispatch = getvar_is_userspace
+	}, {
+		.variable = "mem-size",
+		.dispatch = getvar_mem_size
 	}
 };
 
@@ -264,6 +271,13 @@ static void getvar_partition_size(char *part_name, char *response)
 static void getvar_is_userspace(char *var_parameter, char *response)
 {
 	fastboot_okay("no", response);
+}
+
+static void getvar_mem_size(char *var_parameter, char *response)
+{
+	struct bd_info *bd = gd->bd;
+
+	fastboot_response("OKAY", response, "0x%" PRIx64, bd->bi_memsize);
 }
 
 /**


### PR DESCRIPTION
return mem-size from bd_info data structure

Testing done: $ fastboot getvar mem-size
mem-size: 0x0000000080000000
