### PR TITLE
Kconfig: add HIDE_LOGO_VERSION to Kconfig

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -1017,4 +1017,10 @@ config VIDEO_LINK
 config DRM_SCDC_HELPER
 	bool "Enable scdc helper library"
 
+config HIDE_LOGO_VERSION
+	bool "Hide logo version"
+	help
+		If this is not enabled, a text containing the u-boot version is printed
+		when the logo is shown.
+
 endmenu


### PR DESCRIPTION
Allow to configure from defconfig file to print or not the u-boot version.

Signed-off-by: Jeremie Finiel jeremie.finiel@pulse-origin.com