### PR TITLE
boundary: account for TEE space with RAM top addr

### DIFF
--- a/board/boundary/common/bd_common.c
+++ b/board/boundary/common/bd_common.c
@@ -49,7 +49,15 @@ int board_phys_sdram_size(phys_size_t *sdram_size)
 
 ulong board_get_usable_ram_top(ulong total_size)
 {
-	return MEM_SIZE + CONFIG_SYS_SDRAM_BASE;
+	// In the case of a TEE, rom_pointer[0] contains the TEE base addr
+	// and rom_pointer[1] contains the TEE size
+	if ((rom_pointer[0] > CONFIG_SYS_SDRAM_BASE) &&
+		(rom_pointer[0] < (CONFIG_SYS_SDRAM_BASE + MEM_SIZE)) &&
+		((rom_pointer[0] + rom_pointer[1]) <= (CONFIG_SYS_SDRAM_BASE + MEM_SIZE))) {
+		return rom_pointer[0];
+	} else {
+		return CONFIG_SYS_SDRAM_BASE + MEM_SIZE;
+	}
 }
 #endif
 


### PR DESCRIPTION
Account for TEE size in IMX8M version of board_get_usable_ram_top, which is used to find the U-Boot relocation address in common/board_f.c. This logic is similar to the address and RAM size adjustments in arch/arm/mach-imx/imx8m/soc.c.

Signed-off-by: Thomas Benson <tbensongit@gmail.com>