### PR TITLE
sign-hab: allow execution from other directory

### DIFF
--- a/sign_hab_imx8m.sh
+++ b/sign_hab_imx8m.sh
@@ -106,7 +106,7 @@ fi
 echo Generating IVT header for FIT...
 printf -v IVTADDRESS '%#x' "$((FIT_START_ADDR + IVTOFFSET))"
 printf -v CSFADDRESS '%#x' "$((IVTADDRESS + IVTSIZE))"
-cp doc/imx/habv4/csf_examples/mx8m_mx8mm/template_genIVT.txt genIVT.pl
+cp $SCRIPT_PATH/doc/imx/habv4/csf_examples/mx8m_mx8mm/template_genIVT.txt genIVT.pl
 sed -i "s|_LOADADDR_|$FIT_START_ADDR|g" genIVT.pl
 sed -i "s|_IVTADDRESS_|$IVTADDRESS|g" genIVT.pl
 sed -i "s|_CSFADDRESS_|$CSFADDRESS|g" genIVT.pl


### PR DESCRIPTION
Do not assume that the script is executed where it is located.
In this way we can call this script from another directory.
This is convenient when the build output is not in the source tree.